### PR TITLE
chore(build): Use npm to get tabzilla module

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "helmet": "^0.10.0",
     "jade": "^1.11.0",
     "morgan": "^1.6.1",
-    "mozilla-tabzilla": "mozilla/tabzilla#v0.3.0",
+    "mozilla-tabzilla": "0.4.0",
     "normalize.css": "^3.0.3",
     "serve-static": "^1.10.0",
     "xtend": "^4.0.0"


### PR DESCRIPTION
As of https://github.com/mozilla/tabzilla/commit/fcc52101d4df037f447006aa4cfcecda1aac7c1d, we can now install [**mozilla-tabzilla**](https://www.npmjs.com/package/mozilla-tabzilla) directly from npm instead of using Git tags and branches!

We should use that. This is that PR. We should merge this. Then we'll have that.