### PR TITLE
Run build task in Gulp just before starting file watching in default

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,7 @@ Basically a clone of [eb-node-express-signup](https://github.com/awslabs/eb-node
 
 ```
 npm install
-gulp build
-gulp //sets watches
+gulp // builds and starts watching files for rebuild
 npm start // better yet: nodemon server.js
 ```
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -140,7 +140,7 @@ gulp.task('build', function (done) {
 });
 
 // Watches the things
-gulp.task('default', function() {
+gulp.task('default', ['build'], function() {
   gulp.watch('src/styles/**/*', ['styles']);
   gulp.watch('src/images/**/*', ['images']);
   gulp.watch('src/scripts/**/*', ['scripts']);


### PR DESCRIPTION
Just a small tweak. Kicks off a full build just before starting up the file watching. Helps a bunch when changing git branches, IMO.