### PR TITLE
Add .ebignore

### DIFF
--- a/.ebignore
+++ b/.ebignore
@@ -1,0 +1,12 @@
+# this will override .gitignore for `eb deploy`
+
+# keep private info private
+.elasticbeanstalk/**/*
+.ebextensions/**/*
+
+# don't deploy unncessary files
+.git/**/*
+src/**/*
+node_modules/**/*
+npm-debug.log
+.npm-debug.log


### PR DESCRIPTION
- .gitignore contains `public/`, which is auto-generated but required
  to run the app
- if .ebignore is present, .gitignore is ignored
- works better with the `eb` cli tool to deploy