### PR TITLE
Start up a dev server with gulp-nodemon

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,7 @@ Basically a clone of [eb-node-express-signup](https://github.com/awslabs/eb-node
 
 ```
 npm install
-gulp // builds and starts watching files for rebuild
-npm start // better yet: nodemon server.js
+gulp // watches files for rebuild, starts an app server in dev mode
 ```
 
 Don't forget to set your AWS creds in `.ebenvironment/environment.config`

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -20,6 +20,7 @@ var gulp = require('gulp'),
   buffer = require('vinyl-buffer'),
   del = require('del'),
   runSequence = require('run-sequence'),
+  nodemon = require('gulp-nodemon'),
   debug = process.env.NODE_ENV === 'development';
 
 
@@ -139,8 +140,16 @@ gulp.task('build', function (done) {
   );
 });
 
+gulp.task('server', ['build'], function () {
+  nodemon({
+    script: 'server.js',
+    ext: 'html js',
+    env: { 'NODE_ENV': 'development' }
+  });
+});
+
 // Watches the things
-gulp.task('default', ['build'], function() {
+gulp.task('default', ['build', 'server'], function() {
   gulp.watch('src/styles/**/*', ['styles']);
   gulp.watch('src/images/**/*', ['images']);
   gulp.watch('src/scripts/**/*', ['scripts']);

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "gulp-jade": "^1.1.0",
     "gulp-livereload": "^3.8.0",
     "gulp-minify-css": "^1.1.6",
+    "gulp-nodemon": "^2.0.3",
     "gulp-notify": "^2.2.0",
     "gulp-rename": "^1.2.2",
     "gulp-replace": "^0.5.3",


### PR DESCRIPTION
Another small tweak, one less command to run. Gulp can now start up a nodemon process to run the app server.